### PR TITLE
Tratando email e username repetidos de uma forma mais inteligente

### DIFF
--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -5,6 +5,6 @@ export const createUserController = async (req, res) => {
     const user = await createUserService(req.body);
     res.status(201).json(user);
   } catch (err) {
-    res.status(500).json({ message: err.message });
+    res.json({ error: err.message});
   }
 };


### PR DESCRIPTION
Neste fim de semana, já criei a rota de registro de usuários na minha entidade User. Para evitar problemas, inicialmente eu havia criado uma query que verificava se o username e o email já existiam no banco de dados antes de permitir o registro.

Hoje, refatorei esse processo de uma maneira que, acredito, seja mais eficiente. Eu tinha esquecido que, ao definir o modelo da entidade, já havia especificado que os campos username e email devem ser únicos na tabela. Com isso, estava fazendo uma verificação desnecessária.

Como o próprio Sequelize emite um erro caso o email ou username já existam, apenas analisei o objeto de erro retornado, criei um try/catch no serviço e, se o erro correspondesse à mensagem emitida pelo Sequelize, eu já o enviava tratado para o controlador.